### PR TITLE
reverseCurve should include terminator

### DIFF
--- a/src/Graphics/Gudni/Figure/OpenCurve.hs
+++ b/src/Graphics/Gudni/Figure/OpenCurve.hs
@@ -77,7 +77,7 @@ reverseCurve :: OpenCurve s -> OpenCurve s
 reverseCurve (OpenCurve segments terminator) =
   let terminal = head segments ^. anchor
       extendSegments = segments ++ [Seg terminator Nothing]
-      revCurve = reverse . acrossPairs pullSegments $ segments
+      revCurve = reverse . acrossPairs pullSegments $ extendSegments
   in  OpenCurve revCurve terminal
 
 -- | Connect two curves end to end by translating c1 so that the starting point of 'c1' is equal to the terminator of 'c0'


### PR DESCRIPTION
Here's a simple test case:

`reverseCurve (OpenCurve [ Seg (Point2 0 0.0) (Just (Point2 0.5 0.5)) ] (Point2 1 0)) `

Before: `OpenCurve {_curveSegments = [], _terminator = P (V2 0.0 0.0)}`

After: `OpenCurve {_curveSegments = [V-P (V2 1.0 0.0)C-P (V2 0.5 0.5)], _terminator = P (V2 0.0 0.0)}`

Independent of my last PR (merge order doesn't matter); I just noticed this as I was reading the code.