### PR TITLE
Arc length

### DIFF
--- a/benchmarks/CriterionBenchmarks.hs
+++ b/benchmarks/CriterionBenchmarks.hs
@@ -1,0 +1,26 @@
+module CriterionBenchmarks where
+
+import Graphics.Gudni.Figure.OpenCurve
+import Graphics.Gudni.Figure.Segment
+
+import Linear
+import Linear.Affine
+
+import Criterion
+import Criterion.Main
+
+main = defaultMain
+    [ bench "length of single Bézier segment, analytical" $
+        nf (bezierArcLength (P (V2 0 0)) (P (V2 0.5 0.5))) (P (V2 1 (0 :: Float)))
+    , bench "length of single Bézier segment, Legendre-Gauss" $
+        nf (bezierArcLength  (P (V2 0 0)) (P (V2 0.5 0.001))) (P (V2 1 (0 :: Float)))
+    , bench "length of OpenCurve with straight line" $
+        nf arcLength (OpenCurve [Seg (P (V2 0 0)) Nothing] (P (V2 1 (0 :: Float))))
+    , bench "length of OpenCurve with single Bézier segment" $
+        nf arcLength (OpenCurve [Seg (P (V2 0 0)) (Just (P (V2 0.5 0.5)))] (P (V2 1 (0 :: Float))))
+    , bench "length of OpenCurve with two segments" $
+        nf arcLength (OpenCurve
+                         [ Seg (P (V2 0 (0 :: Float))) (Just (P (V2 0.5 0.5)))
+                         , Seg (P (V2 1 0)) (Just (P (V2 1.5 (-0.5)))) ]
+                         (P (V2 2 0)))
+    ]

--- a/benchmarks/CriterionBenchmarks.hs
+++ b/benchmarks/CriterionBenchmarks.hs
@@ -12,6 +12,8 @@ import Criterion.Main
 main = defaultMain
     [ bench "length of single Bézier segment, analytical" $
         nf (bezierArcLength (P (V2 0 0)) (P (V2 0.5 0.5))) (P (V2 1 (0 :: Float)))
+    , bench "length of single Bézier segment, analytical, Double" $
+        nf (bezierArcLength (P (V2 0 0)) (P (V2 0.5 0.5))) (P (V2 1 (0 :: Double)))
     , bench "length of single Bézier segment, Legendre-Gauss" $
         nf (bezierArcLength  (P (V2 0 0)) (P (V2 0.5 0.001))) (P (V2 1 (0 :: Float)))
     , bench "length of OpenCurve with straight line" $

--- a/gudni.cabal
+++ b/gudni.cabal
@@ -293,3 +293,13 @@ executable paragraph-example
                -threaded
                -- -fprof-auto
                -- "-with-rtsopts=-N -p -s -h -i0.1"
+
+benchmark criterion
+    hs-source-dirs: benchmarks
+    main-is: CriterionBenchmarks.hs
+    ghc-options: -O2 -Wall -rtsopts
+    build-depends: gudni
+                 , base
+                 , criterion
+    default-language:    Haskell2010
+    type: exitcode-stdio-1.0

--- a/src/Graphics/Gudni/Figure/OpenCurve.hs
+++ b/src/Graphics/Gudni/Figure/OpenCurve.hs
@@ -100,6 +100,9 @@ instance NFData s => NFData (OpenCurve s) where
 -- This computation is based on an analytical formula. Since that formula suffers
 -- from numerical instability when the curve is very close to a straight line, we
 -- detect that case and fall back to Legendre-Gauss quadrature.
+{-# SPECIALIZE bezierArcLength :: Point2 Float -> Point2 Float -> Point2 Float -> Float #-}
+{-# SPECIALIZE bezierArcLength :: Point2 Double -> Point2 Double -> Point2 Double -> Double #-}
+-- bezierArcLength runtime increases ~50x without the SPECIALIZE
 bezierArcLength :: (Floating s, Ord s) => Point2 s -> Point2 s -> Point2 s -> s
 bezierArcLength p0 p1 p2 = let
     d2 = p0 - 2.0 * p1 + p2
@@ -142,6 +145,8 @@ bezierArcLength p0 p1 p2 = let
                 * (4.0 * c * a - b * b)
                 * log (((2.0 * a + b) * a2 + 2.0 * sabc) / ba_c2)
 
+{-# SPECIALIZE arcLength :: OpenCurve Float -> Float #-}
+{-# SPECIALIZE arcLength :: OpenCurve Double -> Double #-}
 arcLength :: (Floating s, Ord s) => OpenCurve s -> s
 arcLength (OpenCurve [] _) = 0
 arcLength (OpenCurve (s0 : ss) terminator) =


### PR DESCRIPTION
translated from the Rust code [here](https://github.com/linebender/kurbo/blob/master/src/quadbez.rs#L108), and credited.

On my machine (i5 2.2GHz), `bezierArcLength` takes 60 ns; less for the Legendre-Gauss case.  I think this is plenty fast, even inside the loop when calculating the inverse.  As noted in the comments, SPECIALIZE makes a big difference, so if you need any types besides Float & Double, it's likely worth adding them to the pragmas & benchmarks.